### PR TITLE
debugをconsole.warnに置き換え

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function set(name, value, options) {
   options = options || {};
   var str = encode(name) + '=' + encode(value);
 
-  if (null == value) options.max-age = -1;
+  if (null == value) options['max-age'] = -1;
 
   if (options.maxage) {
     options.expires = new Date(+new Date + options.maxage);

--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ function set(name, value, options) {
 
   if (null == value) options['max-age'] = -1;
 
-  if (options.maxage) {
-    options.expires = new Date(+new Date + options.maxage);
+  if (options['max-age']) {
+    options.expires = new Date(+new Date + options['max-age']);
   }
 
   if (options.path) str += '; path=' + options.path;

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('cookie');
-
 /**
  * Set or get cookie `name` with `value` and `options` object.
  *
@@ -95,7 +93,7 @@ function parse(str) {
     try {
       obj[decode(pair[0])] = decode(pair[1]);
     } catch (e) {
-      debug('error `parse(%o)` - %o', value, e);
+      console.warn('error `parse(' + value +')` - ' + e)
     }
   }
   return obj;
@@ -109,7 +107,7 @@ function encode(value){
   try {
     return encodeURIComponent(value);
   } catch (e) {
-    debug('error `encode(%o)` - %o', value, e)
+    console.warn('error `parse(' + value +')` - ' + e)
   }
 }
 
@@ -121,6 +119,6 @@ function decode(value) {
   try {
     return decodeURIComponent(value);
   } catch (e) {
-    debug('error `decode(%o)` - %o', value, e)
+    console.warn('error `parse(' + value +')` - ' + e)
   }
 }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function set(name, value, options) {
   options = options || {};
   var str = encode(name) + '=' + encode(value);
 
-  if (null == value) options.maxage = -1;
+  if (null == value) options.max-age = -1;
 
   if (options.maxage) {
     options.expires = new Date(+new Date + options.maxage);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
       "./index.js": "index.js"
     }
   },
-  "repository": "t5kz/cookie",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/t5kz/cookie.git"
+  }
   "scripts": {
     "test": "make test"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/t5kz/cookie.git"
-  }
+  },
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
- related issue: https://github.com/plaidev/karte-io/issues/36300
- 目的
    - tracker.jsで呼び出した時に，dubugでminifyが落ちる問題に対処
    - debug -> console.warn に変更